### PR TITLE
fix: open image summary in dedicated viewer window

### DIFF
--- a/addon/content/imageSummaryViewer.html
+++ b/addon/content/imageSummaryViewer.html
@@ -13,7 +13,10 @@
         padding: 0;
         overflow: hidden;
         background: rgba(0, 0, 0, 0.95);
-        font-family: system-ui, -apple-system, sans-serif;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
       }
 
       #root {

--- a/src/modules/ItemPaneSection.ts
+++ b/src/modules/ItemPaneSection.ts
@@ -2222,7 +2222,10 @@ async function loadImageSummary(
     // 点击放大
     imgElement.addEventListener("click", () => {
       void openImageSummaryViewerWindow(imgSrc, targetItem).catch((err) => {
-        ztoolkit.log("[AI-Butler] 打开一图总结预览窗口失败，回退到覆盖层:", err);
+        ztoolkit.log(
+          "[AI-Butler] 打开一图总结预览窗口失败，回退到覆盖层:",
+          err,
+        );
         openImageOverlayFallback(doc, imgSrc);
       });
     });


### PR DESCRIPTION
  ## What changed
  - Open the "One-image summary" (一图总结) preview in a dedicated viewer window instead of a fullscreen overlay.

  ## Why
  - On macOS, closing the fullscreen preview could quit Zotero.
  - The standalone dialog could show "Problem loading page" and fail to render the image.

  ## How
  - Add `addon/content/imageSummaryViewer.html` and open it via `openDialog`, passing the image data via `window.arguments` (with a fallback).
  - Keep the old in-document overlay as a fallback if the viewer window cannot be opened.

  ## Testing
  - Open an item with an image summary → click the image/zoom button → verify the image displays.
  - Close via the red window button / click / Esc → only the viewer closes (Zotero stays open).
