### PR TITLE
fix: open control panel from preferences pane

### DIFF
--- a/src/prefs-entry.ts
+++ b/src/prefs-entry.ts
@@ -14,8 +14,12 @@ import { config } from "../package.json";
     const hooks = addonInstance?.hooks;
 
     if (hooks && typeof hooks.onPrefsEvent === "function") {
-      // Use globalThis to reference the current window object in this context
-      hooks.onPrefsEvent("load", { window: globalThis as unknown as Window });
+      // In PreferencePanes scripts, `globalThis` may be a sandbox global, not the actual Window.
+      // Prefer the real window from document.defaultView if available.
+      const doc: any = (globalThis as any).document;
+      const win: any =
+        doc?.defaultView || (globalThis as any).window || (globalThis as any);
+      hooks.onPrefsEvent("load", { window: win as Window });
     } else {
       console.warn("[AI-Butler][Prefs] hooks.onPrefsEvent not available");
     }


### PR DESCRIPTION
## Problem
  Clicking "Open AI Butler Control Panel" in Zotero Settings → zotero-ai-butler sometimes did nothing.

  ## Root cause
  The preferences pane script was passing a non-Window sandbox/global object into the prefs initializer, so DOM event binding could throw (not an EventTarget) and
  abort the rest of the setup.

  ## Changes
  - Pass the real preference pane `Window` (via `document.defaultView`) to `onPrefsEvent("load")`.
  - Make prefs initialization steps resilient: failures in unrelated prefs UI binding no longer block binding the "Open Control Panel" button.
  - Bind the button using both `command` and `click` events and retry binding until the button is available.
