### PR TITLE
feat: open mindmap in a dedicated viewer window

### DIFF
--- a/addon/content/mindmap.html
+++ b/addon/content/mindmap.html
@@ -82,6 +82,7 @@
       <button id="zoom-out" title="缩小">➖</button>
       <button id="zoom-in" title="放大">➕</button>
       <button id="fit" title="适应画布">🎯</button>
+      <button id="open-window" title="打开预览窗口">⛶</button>
       <button id="export-png" class="primary" title="导出为PNG图片">
         📷 PNG
       </button>
@@ -165,6 +166,41 @@
           markmap.fit();
         }
       });
+
+      // 在侧边栏 iframe 中显示"打开预览窗口"按钮；在独立预览窗口中隐藏
+      (function () {
+        const openBtn = document.getElementById("open-window");
+        if (!openBtn) return;
+
+        const isViewerMode = (() => {
+          try {
+            const params = new URLSearchParams(window.location.search);
+            return params.get("mode") === "viewer";
+          } catch (e) {
+            return false;
+          }
+        })();
+
+        // 顶层窗口（非 iframe）或 viewer 模式下，不需要该按钮
+        const isTopLevel = (() => {
+          try {
+            return window.parent === window;
+          } catch (e) {
+            return true;
+          }
+        })();
+
+        if (isViewerMode || isTopLevel) {
+          openBtn.style.display = "none";
+          return;
+        }
+
+        openBtn.addEventListener("click", () => {
+          try {
+            window.parent.postMessage({ type: "open-mindmap-viewer" }, "*");
+          } catch (e) {}
+        });
+      })();
 
       // PNG 导出功能
       document

--- a/addon/content/mindmapViewer.html
+++ b/addon/content/mindmapViewer.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>思维导图</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        background: #ffffff;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+      }
+
+      #frame {
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+
+      #error {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: #d32f2f;
+        font-size: 14px;
+        padding: 20px;
+        text-align: center;
+        max-width: 720px;
+        line-height: 1.5;
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe id="frame" title="Mindmap"></iframe>
+    <div id="error"></div>
+
+    <script>
+      (function () {
+        function getArgs() {
+          try {
+            return (window.arguments && window.arguments[0]) || {};
+          } catch (e) {
+            return {};
+          }
+        }
+
+        const args = getArgs();
+        const title =
+          (args && args.title ? String(args.title) : "") ||
+          (window.__aiButlerTitle ? String(window.__aiButlerTitle) : "") ||
+          "思维导图";
+        const markdown =
+          (args && args.markdown ? String(args.markdown) : "") ||
+          (window.__aiButlerMindmapMarkdown
+            ? String(window.__aiButlerMindmapMarkdown)
+            : "");
+        const prefsPrefix =
+          (args && args.prefsPrefix ? String(args.prefsPrefix) : "") ||
+          (window.__aiButlerPrefsPrefix
+            ? String(window.__aiButlerPrefsPrefix)
+            : "");
+
+        document.title = title;
+
+        const errorEl = document.getElementById("error");
+        const frame = document.getElementById("frame");
+        frame.src = new URL(
+          "mindmap.html?mode=viewer",
+          window.location.href,
+        ).href;
+
+        if (!markdown) {
+          errorEl.style.display = "block";
+          errorEl.textContent = "未提供思维导图内容。";
+          return;
+        }
+
+        const getPref = (key) => {
+          if (!prefsPrefix) return undefined;
+          try {
+            if (typeof Zotero !== "undefined" && Zotero.Prefs) {
+              return Zotero.Prefs.get(`${prefsPrefix}.${key}`, true);
+            }
+          } catch (e) {}
+          return undefined;
+        };
+
+        const notify = (title, text, type) => {
+          try {
+            new ztoolkit.ProgressWindow(title, {
+              closeOnClick: true,
+              closeTime: 3000,
+            })
+              .createLine({ text, type })
+              .show();
+          } catch (e) {}
+        };
+
+        const saveExport = async (payload) => {
+          const format = payload.format || "png";
+          const filename = payload.filename || `mindmap.${format}`;
+
+          let downloadDir = "";
+          const customPath = String(getPref("mindmapExportPath") || "");
+
+          if (customPath && customPath.trim()) {
+            downloadDir = customPath.trim();
+            try {
+              await IOUtils.makeDirectory(downloadDir, {
+                ignoreExisting: true,
+              });
+            } catch (e) {
+              downloadDir = "";
+            }
+          }
+
+          if (!downloadDir) {
+            try {
+              const desktopDir = Services.dirsvc.get("Desk", Ci.nsIFile);
+              downloadDir = desktopDir.path;
+            } catch (e) {
+              try {
+                const dataDir = Zotero.DataDirectory.dir;
+                downloadDir = PathUtils.join(dataDir, "mindmaps");
+                await IOUtils.makeDirectory(downloadDir, {
+                  ignoreExisting: true,
+                });
+              } catch (e2) {
+                downloadDir = "";
+              }
+            }
+          }
+
+          if (!downloadDir) {
+            throw new Error("No writable export directory.");
+          }
+
+          const filePath = PathUtils.join(downloadDir, filename);
+
+          if (format === "png") {
+            const dataUrl = payload.dataUrl || "";
+            const base64Data = dataUrl.replace(/^data:image\/png;base64,/, "");
+            const binaryString = atob(base64Data);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+              bytes[i] = binaryString.charCodeAt(i);
+            }
+            await IOUtils.write(filePath, bytes);
+          } else if (format === "opml") {
+            const content = String(payload.content || "");
+            const encoder = new TextEncoder();
+            await IOUtils.write(filePath, encoder.encode(content));
+          }
+
+          notify("思维导图已导出", `已保存到: ${filePath}`, "success");
+          try {
+            Zotero.launchFile(filePath);
+          } catch (e) {}
+        };
+
+        window.addEventListener("message", (event) => {
+          if (!event.data || typeof event.data !== "object") return;
+
+          if (event.data.type === "mindmap-ready") {
+            try {
+              frame.contentWindow.postMessage(
+                { type: "render-mindmap", markdown },
+                "*",
+              );
+            } catch (e) {
+              errorEl.style.display = "block";
+              errorEl.textContent = "发送思维导图数据失败。";
+            }
+          }
+
+          if (event.data.type === "export-mindmap") {
+            saveExport(event.data).catch((e) => {
+              notify("导出失败", `错误: ${e}`, "error");
+            });
+          }
+        });
+
+        // Fallback: if the iframe is already loaded and ready message is missed
+        frame.addEventListener("load", () => {
+          setTimeout(() => {
+            try {
+              frame.contentWindow.postMessage(
+                { type: "render-mindmap", markdown },
+                "*",
+              );
+            } catch (e) {}
+          }, 500);
+        });
+
+        window.addEventListener(
+          "keydown",
+          (e) => {
+            if (e.key === "Escape") {
+              try {
+                window.close();
+              } catch (err) {}
+            }
+          },
+          true,
+        );
+      })();
+    </script>
+  </body>
+</html>

--- a/src/modules/ItemPaneSection.ts
+++ b/src/modules/ItemPaneSection.ts
@@ -1069,6 +1069,24 @@ async function loadMindmapContent(
           }
         }
 
+        if (event.data && event.data.type === "open-mindmap-viewer") {
+          ztoolkit.log("[AI-Butler] 收到打开思维导图预览窗口请求");
+          try {
+            await openMindmapViewerWindow(mdContent, targetItem);
+          } catch (e) {
+            ztoolkit.log("[AI-Butler] 打开思维导图预览窗口失败:", e);
+            new ztoolkit.ProgressWindow("AI Butler", {
+              closeOnClick: true,
+              closeTime: 3000,
+            })
+              .createLine({
+                text: "打开思维导图预览窗口失败",
+                type: "error",
+              })
+              .show();
+          }
+        }
+
         // 处理导出请求
         if (event.data && event.data.type === "export-mindmap") {
           ztoolkit.log("[AI-Butler] 收到导出请求, 格式:", event.data.format);
@@ -2429,6 +2447,70 @@ async function openImageSummaryViewerWindow(
   try {
     (dialogWin as any).__aiButlerImageDataUri = imageDataUri;
     (dialogWin as any).__aiButlerTitle = title;
+  } catch {
+    // ignore
+  }
+
+  try {
+    dialogWin.focus();
+  } catch {
+    // ignore
+  }
+}
+
+async function openMindmapViewerWindow(
+  markdown: string,
+  targetItem: any,
+): Promise<void> {
+  const mainWin: any =
+    Zotero && (Zotero as any).getMainWindow
+      ? (Zotero as any).getMainWindow()
+      : (globalThis as any);
+
+  if (typeof mainWin?.openDialog !== "function") {
+    throw new Error("openDialog not available");
+  }
+
+  let itemTitle = "";
+  try {
+    const t = targetItem?.getField?.("title");
+    itemTitle = typeof t === "string" ? t : "";
+  } catch {
+    // ignore
+  }
+
+  const screenObj: any = mainWin?.screen;
+  const height = screenObj
+    ? Math.max(800, Math.floor(screenObj.availHeight * 0.9))
+    : 900;
+  let width = Math.max(650, Math.floor(height * 0.75));
+  if (screenObj) {
+    width = Math.min(width, Math.floor(screenObj.availWidth * 0.9));
+  }
+
+  const title = itemTitle ? `思维导图 - ${itemTitle}` : "思维导图";
+  const viewerURL = `chrome://${config.addonRef}/content/mindmapViewer.html`;
+
+  const dialogWin: any = mainWin.openDialog(
+    viewerURL,
+    "",
+    `chrome,centerscreen,resizable=yes,width=${width},height=${height}`,
+    {
+      markdown,
+      title,
+      prefsPrefix: config.prefsPrefix,
+    },
+  );
+
+  if (!dialogWin) {
+    throw new Error("Failed to open viewer window");
+  }
+
+  // Extra fallback channel in case window.arguments isn't available for some reason
+  try {
+    (dialogWin as any).__aiButlerMindmapMarkdown = markdown;
+    (dialogWin as any).__aiButlerTitle = title;
+    (dialogWin as any).__aiButlerPrefsPrefix = config.prefsPrefix;
   } catch {
     // ignore
   }


### PR DESCRIPTION
  - Add a new “Open in window” button to the Mindmap toolbar in the sidebar.
  - Clicking it opens a dedicated, portrait-oriented preview window for a larger mindmap view.
  - The existing toolbar (zoom/fit/export) is preserved in the viewer, while the “Open in window” button is hidden there.
  - Export actions (PNG/OPML) still work from the viewer window.
