### PR TITLE
fix: 修复文献填表末尾文本乱码，改用 pre 保留原始 Markdown

### DIFF
--- a/src/modules/literatureReviewService.ts
+++ b/src/modules/literatureReviewService.ts
@@ -734,7 +734,7 @@ ${entryList}
       (_match, formula) => `<span class="math">$${formula.trim()}$</span>`,
     );
 
-    // 将原始 Markdown 存储在隐藏元素中，供 findTableNote 提取
+    // 将原始 Markdown 存储在预格式区块中，供 findTableNote 提取
     const escapedRaw = tableContent
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
@@ -742,7 +742,9 @@ ${entryList}
     const noteHtml =
       `<h2>📊 文献表格 - ${itemTitle}</h2>` +
       `<div>${renderedHtml}</div>` +
-      `<div style="display:none" data-ai-table-raw>${escapedRaw}</div>`;
+      `<br/>` +
+      `<p style="color: gray; font-size: 12px;"><em>👇 以下为系统缓存的原始 Markdown 数据（用于追加填表，请勿修改）：</em></p>` +
+      `<pre data-ai-table-raw>${escapedRaw}</pre>`;
 
     const note = new Zotero.Item("note");
     note.libraryID = item.libraryID;


### PR DESCRIPTION
## 变更背景
在文献填表流程中，系统会在笔记底部缓存原始 Markdown（用于后续追加填表读取）。

此前使用隐藏 `div`（`display:none` + `data-ai-table-raw`）保存原始内容，但在 Zotero 编辑器中会出现两个问题：
1. `style="display:none"` 会被过滤，导致缓存文本外漏。
2. `div` 对原始 Markdown 换行保留不稳定，末尾内容会出现连成一行、格式错乱，表现为“乱码感”。

## 本次修改
- 将缓存节点由隐藏 `div` 改为可见 `pre`，继续保留 `data-ai-table-raw` 属性。
- 在正文与缓存区之间增加分隔和提示语，明确该区域用于系统缓存。
- 读取逻辑无需调整（`findTableNote` 的正则已兼容 `div/pre`）。

## 预期效果
- 避免文献填表笔记末尾文本外漏与乱码。
- 保留原始 Markdown 的换行与结构，保障后续追加填表读取稳定。