### PR TITLE
fix: refactor Gemini HTTP/2 workaround and add OpenAI diagnostic logging

### DIFF
--- a/src/modules/imageClient.ts
+++ b/src/modules/imageClient.ts
@@ -113,6 +113,80 @@ export class ImageClient {
     return "gemini";
   }
 
+  /**
+   * Gecko HTTP/2 workaround for Gemini direct connections.
+   *
+   * Temporarily disables HTTP/2 to force HTTP/1.1 and raises network
+   * timeout prefs to match the configured request timeout.
+   *
+   * Only used for the Gemini path where the target host has no existing
+   * HTTP/2 connection in the pool.  NOT used for OpenAI-compatible
+   * proxies — those require server-side proxy_read_timeout tuning.
+   */
+  private static applyGeckoHttpWorkaround(
+    requestTimeoutMs: number,
+  ): { key: string; type: "int" | "bool"; val: any }[] {
+    const savedPrefs: { key: string; type: "int" | "bool"; val: any }[] = [];
+
+    const tuneIntPref = (key: string, newVal: number) => {
+      try {
+        let old: number | null = null;
+        try {
+          old = Services.prefs.getIntPref(key);
+        } catch {
+          /* pref does not exist */
+        }
+        savedPrefs.push({ key, type: "int", val: old });
+        Services.prefs.setIntPref(key, newVal);
+      } catch {
+        /* ignore */
+      }
+    };
+
+    const tuneBoolPref = (key: string, newVal: boolean) => {
+      try {
+        let old: boolean | null = null;
+        try {
+          old = Services.prefs.getBoolPref(key);
+        } catch {
+          /* pref does not exist */
+        }
+        savedPrefs.push({ key, type: "bool", val: old });
+        Services.prefs.setBoolPref(key, newVal);
+      } catch {
+        /* ignore */
+      }
+    };
+
+    tuneBoolPref("network.http.http2.enabled", false);
+    tuneBoolPref("network.http.spdy.enabled", false);
+    const networkTimeoutSeconds = Math.max(
+      30,
+      Math.ceil(requestTimeoutMs / 1000),
+    );
+    tuneIntPref("network.http.response.timeout", networkTimeoutSeconds);
+    tuneIntPref("network.http.connection-timeout", networkTimeoutSeconds);
+
+    return savedPrefs;
+  }
+
+  private static restoreGeckoPrefs(
+    savedPrefs: { key: string; type: "int" | "bool"; val: any }[],
+  ): void {
+    for (const { key, type, val } of savedPrefs) {
+      try {
+        if (val !== null) {
+          if (type === "bool") Services.prefs.setBoolPref(key, val);
+          else Services.prefs.setIntPref(key, val);
+        } else {
+          Services.prefs.clearUserPref(key);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
   private static normalizeApiUrl(url: string): string {
     return (url || "").trim().replace(/\/$/, "");
   }
@@ -1361,6 +1435,14 @@ export class ImageClient {
       const responseBody =
         error?.xmlhttp?.response || error?.xmlhttp?.responseText || "";
 
+      ztoolkit.log(
+        `[AI-Butler] OpenAI 生图请求失败 — ` +
+          `status=${statusCode}, ` +
+          `name=${error?.name}, ` +
+          `message=${error?.message}, ` +
+          `result=${error?.result ? "0x" + error.result.toString(16) : "N/A"}`,
+      );
+
       let errorMessage = error?.message || "OpenAI 兼容生图请求失败";
       let errorName = "NetworkError";
 
@@ -1416,6 +1498,12 @@ export class ImageClient {
     } finally {
       cleanupAbortSignal?.();
     }
+
+    ztoolkit.log(
+      `[AI-Butler] OpenAI 生图请求完成 — ` +
+        `status=${response.status}, ` +
+        `responseSize=${response.response?.length ?? 0}`,
+    );
 
     if (response.status !== 200) {
       throw new ImageGenerationError(`HTTP ${response.status}`, {
@@ -1601,53 +1689,9 @@ export class ImageClient {
     );
     const requestStartTime = Date.now();
 
-    // Gecko 的 HTTP/2 实现有独立的 stream 空闲超时 (~30-45s)，
-    // 不受 network.http.response.timeout 等偏好控制。
-    // Gemini 生成 4K 图片时服务器在 50-120 秒内不返回任何数据，触发此超时。
-    // 解决方案：临时禁用 HTTP/2 强制 HTTP/1.1（无 stream 层超时），
-    // 并提升网络超时偏好，请求完成后恢复。
-    const savedPrefs: { key: string; type: "int" | "bool"; val: any }[] = [];
-
-    const tuneIntPref = (key: string, newVal: number) => {
-      try {
-        let old: number | null = null;
-        try {
-          old = Services.prefs.getIntPref(key);
-        } catch {
-          /* pref does not exist */
-        }
-        savedPrefs.push({ key, type: "int", val: old });
-        Services.prefs.setIntPref(key, newVal);
-      } catch {
-        /* ignore */
-      }
-    };
-
-    const tuneBoolPref = (key: string, newVal: boolean) => {
-      try {
-        let old: boolean | null = null;
-        try {
-          old = Services.prefs.getBoolPref(key);
-        } catch {
-          /* pref does not exist */
-        }
-        savedPrefs.push({ key, type: "bool", val: old });
-        Services.prefs.setBoolPref(key, newVal);
-      } catch {
-        /* ignore */
-      }
-    };
-
-    tuneBoolPref("network.http.http2.enabled", false);
-    tuneBoolPref("network.http.spdy.enabled", false);
-    const networkTimeoutSeconds = Math.max(
-      30,
-      Math.ceil(requestTimeoutMs / 1000),
-    );
-    tuneIntPref("network.http.response.timeout", networkTimeoutSeconds);
-    tuneIntPref("network.http.connection-timeout", networkTimeoutSeconds);
-
     throwIfAborted(options?.abortSignal);
+
+    const savedPrefs = this.applyGeckoHttpWorkaround(requestTimeoutMs);
 
     let response: any;
     let abortError: Error | null = null;
@@ -1724,20 +1768,7 @@ export class ImageClient {
       });
     } finally {
       cleanupAbortSignal?.();
-
-      // 恢复所有 Gecko 偏好
-      for (const { key, type, val } of savedPrefs) {
-        try {
-          if (val !== null) {
-            if (type === "bool") Services.prefs.setBoolPref(key, val);
-            else Services.prefs.setIntPref(key, val);
-          } else {
-            Services.prefs.clearUserPref(key);
-          }
-        } catch {
-          /* ignore */
-        }
-      }
+      this.restoreGeckoPrefs(savedPrefs);
     }
 
     const elapsedSec = ((Date.now() - requestStartTime) / 1000).toFixed(1);


### PR DESCRIPTION
## Summary
- 将 Gemini 生图路径中内联的 Gecko HTTP/2 workaround（禁用 HTTP/2 + 调整网络超时）提取为可复用的 `applyGeckoHttpWorkaround`/`restoreGeckoPrefs` 方法
- 明确该 workaround 仅适用于 Gemini 直连场景；OpenAI 兼容代理的超时问题需通过服务端 `proxy_read_timeout` 配置解决
- 为 OpenAI 生图路径添加诊断日志，记录请求失败时的详细错误信息（status、name、message、Gecko result code）和成功时的响应元数据

## Background
一图总结功能在通过 OpenAI 兼容代理（如 nginx 反向代理）调用生图 API 时，复杂论文海报生成耗时 >60s，触发 nginx 默认的 `proxy_read_timeout=60s`，导致连接被代理主动断开。经排查确认根因为服务端代理超时，而非客户端 HTTP/2 协议问题。

## Test plan
- [x] 调整服务端 `proxy_read_timeout 300s` 后，长耗时生图请求（~194s）正常返回
- [x] `npm run build` 通过
- [x] `tsc --noEmit` 类型检查通过
- [x] Prettier + ESLint 检查通过