### PR TITLE
Fix Zotero 10 selected collection API compatibility

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -23,6 +23,7 @@
  */
 
 import { getString, initLocale, getLocaleID } from "./utils/locale";
+import { getSelectedCollection } from "./utils/collectionSelection";
 import { registerPrefsScripts } from "./modules/preferenceScript";
 import { createZToolkit } from "./utils/ztoolkit";
 import { TaskQueueManager } from "./modules/taskQueue";
@@ -2057,7 +2058,7 @@ async function handleLiteratureReview() {
   try {
     // 获取当前选中的分类
     const zoteroPane = Zotero.getActiveZoteroPane();
-    const collection = zoteroPane?.getSelectedCollection();
+    const collection = getSelectedCollection(zoteroPane);
 
     if (!collection) {
       new ztoolkit.ProgressWindow("AI Butler", {
@@ -2103,7 +2104,7 @@ async function handleLiteratureReview() {
 async function handleClearCollectionAiNotes() {
   try {
     const zoteroPane = Zotero.getActiveZoteroPane();
-    const collection = zoteroPane?.getSelectedCollection();
+    const collection = getSelectedCollection(zoteroPane);
 
     if (!collection) {
       showAIButlerToast(getString("collection-error-no-collection"), "error");
@@ -2199,7 +2200,7 @@ type CollectionExportDialogChoice = {
 
 async function handleExportCollectionNotes() {
   try {
-    const collection = Zotero.getActiveZoteroPane()?.getSelectedCollection();
+    const collection = getSelectedCollection();
     if (!collection) {
       showAIButlerToast(getString("collection-error-no-collection"), "error");
       return;

--- a/src/modules/quickChatRelatedSelector.ts
+++ b/src/modules/quickChatRelatedSelector.ts
@@ -1,4 +1,5 @@
 import { getString } from "../utils/locale";
+import { getSelectedCollection } from "../utils/collectionSelection";
 import {
   createQuickChatRelatedItemRef,
   getQuickChatRelatedLimit,
@@ -87,8 +88,7 @@ function getQuickChatOverlayDocument(ownerDoc: Document): Document {
 
 function getQuickChatSelectedCollectionId(): number | null {
   try {
-    const collection =
-      Zotero.getActiveZoteroPane?.()?.getSelectedCollection?.();
+    const collection = getSelectedCollection();
     return typeof collection?.id === "number" ? collection.id : null;
   } catch {
     return null;

--- a/src/modules/views/settings/NoteExportSettingsPage.ts
+++ b/src/modules/views/settings/NoteExportSettingsPage.ts
@@ -15,6 +15,7 @@ import {
   createStyledButton,
 } from "../ui/components";
 import { getString } from "../../../utils/locale";
+import { getSelectedCollection } from "../../../utils/collectionSelection";
 
 export class NoteExportSettingsPage {
   private container: HTMLElement;
@@ -259,7 +260,7 @@ export class NoteExportSettingsPage {
     );
     Object.assign(addSelectedButton.style, { borderRadius: "10px" });
     addSelectedButton.addEventListener("click", () => {
-      const collection = Zotero.getActiveZoteroPane()?.getSelectedCollection();
+      const collection = getSelectedCollection();
       if (!collection) {
         showToast(
           getString("settings-note-export-select-collection-first"),

--- a/src/utils/collectionSelection.ts
+++ b/src/utils/collectionSelection.ts
@@ -9,14 +9,16 @@ export function getSelectedCollection(
       ? collections[0]
       : collections;
 
-    if (typeof collection === "number") {
-      return (
-        (Zotero.Collections.get(collection) as Zotero.Collection | false) ||
-        null
-      );
-    }
+    const id =
+      typeof collection === "number"
+        ? collection
+        : typeof (collection as any)?.id === "number"
+          ? (collection as any).id
+          : null;
 
-    return (collection as Zotero.Collection | null) || null;
+    return typeof id === "number"
+      ? ((Zotero.Collections.get(id) as Zotero.Collection | false) || null)
+      : null;
   }
 
   if (typeof zoteroPane.getSelectedCollection === "function") {

--- a/src/utils/collectionSelection.ts
+++ b/src/utils/collectionSelection.ts
@@ -17,14 +17,14 @@ export function getSelectedCollection(
           : null;
 
     return typeof id === "number"
-      ? ((Zotero.Collections.get(id) as Zotero.Collection | false) || null)
+      ? (Zotero.Collections.get(id) as Zotero.Collection | false) || null
       : null;
   }
 
   if (typeof zoteroPane.getSelectedCollection === "function") {
     return (
-      (zoteroPane.getSelectedCollection() as Zotero.Collection | false | null) ||
-      null
+      (zoteroPane.getSelectedCollection() as
+        Zotero.Collection | false | null) || null
     );
   }
 

--- a/src/utils/collectionSelection.ts
+++ b/src/utils/collectionSelection.ts
@@ -1,0 +1,30 @@
+export function getSelectedCollection(
+  zoteroPane: any = Zotero.getActiveZoteroPane?.(),
+): Zotero.Collection | null {
+  if (!zoteroPane) return null;
+
+  if (typeof zoteroPane.getSelectedCollections === "function") {
+    const collections = zoteroPane.getSelectedCollections();
+    const collection = Array.isArray(collections)
+      ? collections[0]
+      : collections;
+
+    if (typeof collection === "number") {
+      return (
+        (Zotero.Collections.get(collection) as Zotero.Collection | false) ||
+        null
+      );
+    }
+
+    return (collection as Zotero.Collection | null) || null;
+  }
+
+  if (typeof zoteroPane.getSelectedCollection === "function") {
+    return (
+      (zoteroPane.getSelectedCollection() as Zotero.Collection | false | null) ||
+      null
+    );
+  }
+
+  return null;
+}

--- a/test/collectionSelection.test.ts
+++ b/test/collectionSelection.test.ts
@@ -1,0 +1,71 @@
+import { expect } from "chai";
+import { getSelectedCollection } from "../src/utils/collectionSelection";
+
+describe("collection selection compatibility", function () {
+  let originalCollectionsGet: typeof Zotero.Collections.get;
+
+  before(function () {
+    originalCollectionsGet = Zotero.Collections.get;
+  });
+
+  afterEach(function () {
+    Zotero.Collections.get = originalCollectionsGet;
+  });
+
+  function stubCollectionLookup(collection: Zotero.Collection): void {
+    Zotero.Collections.get = ((id: number) =>
+      id === collection.id
+        ? collection
+        : false) as typeof Zotero.Collections.get;
+  }
+
+  it("uses the Zotero 10 plural API and resolves collection objects", function () {
+    const collection = { id: 42, name: "Selected" } as Zotero.Collection;
+    let legacyCallCount = 0;
+    stubCollectionLookup(collection);
+
+    const result = getSelectedCollection({
+      getSelectedCollections: () => [collection],
+      getSelectedCollection: () => {
+        legacyCallCount += 1;
+        return false;
+      },
+    });
+
+    expect(result).to.equal(collection);
+    expect(legacyCallCount).to.equal(0);
+  });
+
+  it("resolves numeric IDs returned by the Zotero 10 API", function () {
+    const collection = { id: 84, name: "Selected by ID" } as Zotero.Collection;
+    stubCollectionLookup(collection);
+
+    const result = getSelectedCollection({
+      getSelectedCollections: () => [collection.id],
+    });
+
+    expect(result).to.equal(collection);
+  });
+
+  it("returns null for empty or invalid Zotero 10 selections", function () {
+    Zotero.Collections.get = (() => false) as typeof Zotero.Collections.get;
+
+    expect(
+      getSelectedCollection({ getSelectedCollections: () => [] }),
+    ).to.equal(null);
+    expect(
+      getSelectedCollection({ getSelectedCollections: () => [{ id: 999 }] }),
+    ).to.equal(null);
+  });
+
+  it("falls back to the Zotero 7 singular API", function () {
+    const collection = { id: 126, name: "Legacy" } as Zotero.Collection;
+
+    expect(
+      getSelectedCollection({ getSelectedCollection: () => collection }),
+    ).to.equal(collection);
+    expect(
+      getSelectedCollection({ getSelectedCollection: () => false }),
+    ).to.equal(null);
+  });
+});


### PR DESCRIPTION
### Summary

This PR fixes Zotero 10 compatibility for selected collection access.

Zotero 10 removed `ZoteroPane.getSelectedCollection()` and now expects plugins to use `ZoteroPane.getSelectedCollections()`. Direct calls to the removed API cause collection-related actions to fail.

### Changes

- Add a `getSelectedCollection()` compatibility helper.
- Use `getSelectedCollections()` when available.
- Preserve fallback support for older Zotero versions that still expose `getSelectedCollection()`.
- Update collection actions, note export settings, and quick chat related selection to use the helper.

### Fixed issue

In Zotero 10.0 with AI Butler v4.1.0-beta.2, exporting AI notes from a collection fails with:

`ZoteroPane.getSelectedCollection() was removed -- use ZoteroPane.getSelectedCollections()`

### Testing

- Confirmed the error occurs in Zotero 10.0 when using “Export AI notes in this collection”.
- Prepared and syntax-checked a local patched XPI with the same compatibility logic.